### PR TITLE
Fix make-my-branch call to git log/cherry-pick

### DIFF
--- a/make-my-branch
+++ b/make-my-branch
@@ -58,4 +58,4 @@ git fetch remote
 git branch "${localbranch}" remote/"${branch}"
 git checkout "${localbranch}"
 git rebase "${treeish}"
-git log --reverse --pretty=format:%H origin/reviews | xargs -n 1 git cp --strategy recursive -Xtheirs
+git log --reverse --pretty=format:%H origin/master | xargs -n 1 git cherry-pick --strategy recursive -Xtheirs


### PR DESCRIPTION
'cp' isn't a valid shortcut for cherry-pick everywhere, and the reviews
branch does not seem to exist; it looks like 'master' is the correct one.

Signed-off-by: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>